### PR TITLE
Fix service and method names to conform to kRPC identifier requirements

### DIFF
--- a/krpcmj/Partials/Helpers.cs
+++ b/krpcmj/Partials/Helpers.cs
@@ -15,7 +15,7 @@ namespace krpcmj
         /// Returns the DV stats for the mjvessel  
         /// </summary>
         [KRPCProcedure]
-        public static IList<IList<double>> dvstats()
+        public static IList<IList<double>> DVStats()
         {
             IList<IList<double>> stats = new List<IList<double>>();
             MechJebCore activejeb = GetJeb();
@@ -51,7 +51,7 @@ namespace krpcmj
 
         {
 
-            double timeraw =  mjvessel.orbit.NextTimeOfRadius(Planetarium.GetUniversalTime(), (alt+apvessel.Orbit.Body.EquatorialRadius));
+            double timeraw =  mjvessel.orbit.NextTimeOfRadius(Planetarium.GetUniversalTime(), (alt+APVessel.Orbit.Body.EquatorialRadius));
             return timeraw - Planetarium.GetUniversalTime();
         }
 
@@ -59,7 +59,7 @@ namespace krpcmj
         /// Returns Vessel's time of closest approach to it's target   
         /// </summary>
         [KRPCProcedure]
-        public static double closestAppTime()
+        public static double ClosestAppTime()
         {
                 Vessel target = mjvessel.targetObject as Vessel;
                 return mjvessel.orbit.NextClosestApproachTime(target.orbit, Planetarium.GetUniversalTime())-Planetarium.GetUniversalTime();
@@ -69,7 +69,7 @@ namespace krpcmj
         /// Returns Vessel's distance at closest approach to it's target   
         /// </summary>
         [KRPCProcedure]
-        public static double closestAppDist()
+        public static double ClosestAppDist()
         {
             Vessel target = mjvessel.targetObject as Vessel;
             return mjvessel.orbit.NextClosestApproachDistance(target.orbit, Planetarium.GetUniversalTime());
@@ -79,7 +79,7 @@ namespace krpcmj
         /// Returns relative inclination between vessel and it's target   
         /// </summary>
         [KRPCProcedure]
-        public static double relativeInc()
+        public static double RelativeInc()
         {
             Vessel target = mjvessel.targetObject as Vessel;
             return mjvessel.orbit.RelativeInclination(target.orbit);
@@ -101,14 +101,14 @@ namespace krpcmj
         /// Returns the time until Equatorial Ascending Node   
         /// </summary>
         [KRPCProcedure]
-        public static double timeEqAn()
+        public static double TimeEqAn()
         { return mjvessel.orbit.TimeOfAscendingNodeEquatorial(Planetarium.GetUniversalTime()) - Planetarium.GetUniversalTime();}
 
         /// <summary>
         /// Returns the time until Euatorial Descending Node   
         /// </summary>
         [KRPCProcedure]
-        public static double timeEqDn()
+        public static double TimeEqDn()
         {return mjvessel.orbit.TimeOfDescendingNodeEquatorial(Planetarium.GetUniversalTime()) - Planetarium.GetUniversalTime();}
 
 
@@ -129,14 +129,14 @@ namespace krpcmj
         /// Returns the time until next Equatorial Ascending Node   
         /// </summary>
         [KRPCProcedure]
-        public static double timeTgtAn()
+        public static double TimeTgtAn()
         { return mjvessel.orbit.TimeOfAscendingNode(mjvessel.targetObject.GetOrbit(), Planetarium.GetUniversalTime())-Planetarium.GetUniversalTime(); }
 
         /// <summary>
         /// Returns the time until next Euatorial Descending Node   
         /// </summary>
         [KRPCProcedure]
-        public static double timeTgtDn()
+        public static double TimeTgtDn()
         { return mjvessel.orbit.TimeOfDescendingNode(mjvessel.targetObject.GetOrbit(), Planetarium.GetUniversalTime()) - Planetarium.GetUniversalTime() ; }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace krpcmj
         /// Returns the difference in velocity now between vessel and target   
         /// </summary>
         [KRPCProcedure]
-        public static double relativeVel()
+        public static double RelativeVel()
         {
                 Vessel target = mjvessel.targetObject as Vessel;
                 Vector3d deltav = OrbitalManeuverCalculator.DeltaVToMatchVelocities(mjvessel.orbit, Planetarium.GetUniversalTime(), target.orbit);
@@ -164,14 +164,14 @@ namespace krpcmj
         /// Should return the phase angle of vessel in reference to target...  but...  doesn't.  Needs work   
         /// </summary>
         [KRPCProcedure]
-        public static double phaseAngle()
+        public static double PhaseAngle()
         {return mjvessel.orbit.PhaseAngle(mjvessel.targetObject.GetOrbit(), Planetarium.GetUniversalTime()); }
 
         /// <summary>
         /// Returns the biome currently underneath vessel
         /// </summary>
         [KRPCProcedure]
-        public static string biome()
+        public static string Biome()
         {return mjvessel.mainBody.BiomeMap.GetAtt(mjvessel.latitude * Math.PI / 180d, mjvessel.longitude * Math.PI / 180d).name; }
 
     }

--- a/krpcmj/Partials/MP.cs
+++ b/krpcmj/Partials/MP.cs
@@ -85,7 +85,7 @@ namespace krpcmj
         /// Create ManeuverNode to match planes between ap_vessel and it's target
         /// </summary>
         [KRPCProcedure]
-        public static void mpMatchplanes()
+        public static void MPMatchplanes()
         {
             MechJebCore activejeb = GetJeb();
             if (activejeb != null)
@@ -111,7 +111,7 @@ namespace krpcmj
         /// Create ManeuverNode to Circularize at a given time   
         /// </summary>
         [KRPCProcedure]
-        public static void mpCirc(double time)
+        public static void MPCirc(double time)
         {
             MechJebCore activejeb = GetJeb();
             if (activejeb != null)
@@ -125,7 +125,7 @@ namespace krpcmj
         /// Create a ManeuverNode to change Apoapsis at a given time   
         /// </summary>
         [KRPCProcedure]
-        public static void mpApa(double time, double apa)
+        public static void MPApa(double time, double apa)
         {
             MechJebCore activejeb = GetJeb();
             if (activejeb != null)
@@ -139,7 +139,7 @@ namespace krpcmj
         /// Create a ManeuverNode to change Periapsis at a given time   
         /// </summary>
         [KRPCProcedure]
-        public static void mpPea(double time, double pea)
+        public static void MPPea(double time, double pea)
         {
             MechJebCore activejeb = GetJeb();
             if (activejeb != null)
@@ -153,7 +153,7 @@ namespace krpcmj
         /// Create a ManeuverNode to change inclination at a given time   
         /// </summary>
         [KRPCProcedure]
-        public static void mpInc(double time, double inc)
+        public static void MPInc(double time, double inc)
         {
             MechJebCore activejeb = GetJeb();
             if (activejeb != null)
@@ -167,7 +167,7 @@ namespace krpcmj
         /// Creates a ManeuverNode to match velocity with target at a given time   
         /// </summary>
         [KRPCProcedure]
-        public static void mpMatchVelocity(double time)
+        public static void MPMatchVelocity(double time)
         {
             MechJebCore activejeb = GetJeb();
             if (activejeb != null)
@@ -182,7 +182,7 @@ namespace krpcmj
         /// Creates a ManeuverNode to Hohmann Transfer to target   
         /// </summary>
         [KRPCProcedure]
-        public static void mpHohmann()
+        public static void MPHohmann()
         {  
             MechJebCore activejeb = GetJeb();
             if (activejeb != null)
@@ -198,7 +198,7 @@ namespace krpcmj
         /// Creates a ManeuverNode to transfer to another planet at next Low Delta-V Window  
         /// </summary>
         [KRPCProcedure]
-        public static void mpPlanet()
+        public static void MPPlanet()
         {
             MechJebCore activejeb = GetJeb();
             if (activejeb != null)
@@ -214,7 +214,7 @@ namespace krpcmj
         /// Creates a ManeuverNode to adjust closest approach to target
         /// </summary>
         [KRPCProcedure]
-        public static void mpFineTuneCa(double distance)
+        public static void MPFineTuneCa(double distance)
         {
             MechJebCore activejeb = GetJeb();
             if (activejeb != null)

--- a/krpcmj/Partials/Rdzv.cs
+++ b/krpcmj/Partials/Rdzv.cs
@@ -46,7 +46,7 @@ namespace krpcmj
         /// Target distance for Rendezvous AP
         /// </summary>
         [KRPCProperty]
-        public static double rdzvDist
+        public static double RdzvDist
         {
             get
             {
@@ -80,7 +80,7 @@ namespace krpcmj
         /// Sets Max number of orbits for the Rendezvous AP 
         /// </summary>
         [KRPCProperty]
-        public static double rdzvMaxOrbits
+        public static double RdzvMaxOrbits
         {
             get
             {
@@ -114,7 +114,7 @@ namespace krpcmj
         /// Rendezvous Autopilot Status Message
         /// </summary>
         [KRPCProperty]
-        public static string rdzvMessage
+        public static string RdzvMessage
         {
             get
             {

--- a/krpcmj/Partials/SmartASS.cs
+++ b/krpcmj/Partials/SmartASS.cs
@@ -4,41 +4,42 @@ using KRPC.Service.Attributes;
 
 namespace krpcmj
 {
+  [KRPCEnum(Service = "KRPCMJ")]
+    public enum SAMode
+    {
+        OFF,
+        KILLROT,
+        NODE,
+        SURFACE,
+        PROGRADE,
+        RETROGRADE,
+        NORMAL_PLUS,
+        NORMAL_MINUS,
+        RADIAL_PLUS,
+        RADIAL_MINUS,
+        RELATIVE_PLUS,
+        RELATIVE_MINUS,
+        TARGET_PLUS,
+        TARGET_MINUS,
+        PARALLEL_PLUS,
+        PARALLEL_MINUS,
+        ADVANCED,
+        AUTO,
+        SURFACE_PROGRADE,
+        SURFACE_RETROGRADE,
+        HORIZONTAL_PLUS,
+        HORIZONTAL_MINUS,
+        VERTICAL_PLUS
+    }
+
     public static partial class krpcmj
     {
-        [KRPCEnum]
-        public enum SAMode
-        {
-            OFF,
-            KILLROT,
-            NODE,
-            SURFACE,
-            PROGRADE,
-            RETROGRADE,
-            NORMAL_PLUS,
-            NORMAL_MINUS,
-            RADIAL_PLUS,
-            RADIAL_MINUS,
-            RELATIVE_PLUS,
-            RELATIVE_MINUS,
-            TARGET_PLUS,
-            TARGET_MINUS,
-            PARALLEL_PLUS,
-            PARALLEL_MINUS,
-            ADVANCED,
-            AUTO,
-            SURFACE_PROGRADE,
-            SURFACE_RETROGRADE,
-            HORIZONTAL_PLUS,
-            HORIZONTAL_MINUS,
-            VERTICAL_PLUS
-        }
 
         /// <summary>
         /// The smartASS mode   
         /// </summary>
         [KRPCProperty]
-        public static SAMode saMode
+        public static SAMode SAMode
         {
             set
             {
@@ -72,7 +73,7 @@ namespace krpcmj
         /// Toggles smartASS off 
         /// </summary>
         [KRPCProperty]
-        public static bool saStatus
+        public static bool SAStatus
         {
             get
             {
@@ -116,7 +117,7 @@ namespace krpcmj
         /// Activates smartASS and Sets Heading, Pitch and Roll for Surface Reference mode
         /// </summary>
         [KRPCProcedure]
-        public static void saSurface(float hdg, float pit, float rol)
+        public static void SASurface(float hdg, float pit, float rol)
         {
             MechJebCore activejeb =krpcmj.GetJeb();
             if (activejeb != null)
@@ -138,7 +139,7 @@ namespace krpcmj
         /// Enabling force roll and accepting a float for roll value
         /// </summary>
         [KRPCProcedure]
-        public static void saForceroll(float rol)
+        public static void SAForceroll(float rol)
         {
             MechJebCore activejeb =krpcmj.GetJeb();
             if (activejeb != null)
@@ -156,7 +157,7 @@ namespace krpcmj
         /// Disables Force Roll
         /// </summary>
         [KRPCProcedure]
-        public static void saForcerollClear()
+        public static void SAForcerollClear()
         {
             MechJebCore activejeb =krpcmj.GetJeb();
             if (activejeb != null)

--- a/krpcmj/krpcmj.cs
+++ b/krpcmj/krpcmj.cs
@@ -11,7 +11,7 @@ namespace krpcmj
     /// <summary>
     /// Static Service for Interacting with Mechjeb 2.  
     /// </summary>
-    [KRPCService(GameScene = GameScene.Flight)]
+    [KRPCService(Name = "KRPCMJ", GameScene = GameScene.Flight)]
     public static partial class krpcmj
     {
         public static Vessel mjvessel;
@@ -20,7 +20,7 @@ namespace krpcmj
         /// Vessel currently controlled by krpcmj.  
         /// </summary>
         [KRPCProperty]
-        public static KRPC.SpaceCenter.Services.Vessel apvessel
+        public static KRPC.SpaceCenter.Services.Vessel APVessel
         {
             set { mjvessel = value.InternalVessel; }
             get {
@@ -36,7 +36,7 @@ namespace krpcmj
         /// Returns an int that bitwise encodes the mechjeb autopilot status - 0=AP off   
         /// </summary>
         [KRPCProperty]    //Probably need to change this to a list of [flags]enum s
-        public static int apStatus
+        public static int APStatus
         {
             get
             {


### PR DESCRIPTION
This plugin doesn't work with kRPC v0.4, as it now has stricter requirements on service and method names using CamelCase. This patch fixes this.